### PR TITLE
[ext_gdb] Python 2 compatibility

### DIFF
--- a/ext_gdb/sync.py
+++ b/ext_gdb/sync.py
@@ -41,6 +41,13 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
+if sys.version_info[0] == 2:
+    try:
+        from future import super
+    except ImportError as e:
+        print("[sync] 'future' package is needed (e.g., 'pip install future')")
+        raise(e)
+
 
 HOST = "localhost"
 PORT = 9100


### PR DESCRIPTION
super() syntax is not compatible with Python2. Use builtins backports from future package.

See: https://github.com/bootleg/ret-sync/issues/40
Thx to @mpalmer for reporting the issue.